### PR TITLE
Add to Guestlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,4 @@ this list!
 
 - June Kelly ([@JuneKelly](https://github.com/JuneKelly)), original author of
   Carpalx MacOS
+- Sam ([@samglt](https://github.com/samglt))


### PR DESCRIPTION
Thanks for making this! 
It turns out that many keyboard shortcuts in XCode don't work with the other Mac Carpalx layouts that I was using. Emacs-like navigation finally works like it should with this